### PR TITLE
Adding exponential backoff to all Layer requests.

### DIFF
--- a/glare.go
+++ b/glare.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 const baseURL = "https://api.layer.com"
@@ -26,6 +28,14 @@ type Layer struct {
 	ID      string
 	Token   string
 	Version string
+	Backoff Backoff
+}
+
+// Backoff is a configuration to use when implementing exponential backoff. If numTries is 1 or 0 then no backoff will be performed.
+type Backoff struct {
+	NumTries int
+	MinTime  int
+	MaxTime  int
 }
 
 // ExtractUUID returns the 36 character uuid value at the end of a layer id.
@@ -37,8 +47,17 @@ func ExtractUUID(id string) string {
 }
 
 // New is a convenience method for easily creating
-func New(id string, token string, version string) Layer {
-	return Layer{ID: id, Token: token, Version: version}
+func New(id string, token string, version string, backoff Backoff) Layer {
+	return Layer{ID: id, Token: token, Version: version, Backoff: backoff}
+}
+
+// NewBackoff returns a new Backoff configuration to be used with the Layer client.
+func NewBackoff(numTries, minTime, maxTime int) Backoff {
+	return Backoff{
+		NumTries: numTries,
+		MinTime:  minTime,
+		MaxTime:  maxTime,
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -50,7 +69,7 @@ func New(id string, token string, version string) Layer {
 func (l Layer) GetConversationsByUser(userID string) ([]Conversation, error) {
 	var conversations []Conversation
 	url := fmt.Sprintf("%s/apps/%s/users/%s/conversations", baseURL, l.ID, userID)
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return conversations, err
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
@@ -73,7 +92,7 @@ func (l Layer) GetConversationsByUser(userID string) ([]Conversation, error) {
 func (l Layer) GetConversationByUser(userID string, conversationID string) (Conversation, error) {
 	var conversation Conversation
 	url := fmt.Sprintf("%s/apps/%s/users/%s/conversations/%s", baseURL, l.ID, userID, conversationID)
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return conversation, err
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
@@ -96,7 +115,7 @@ func (l Layer) GetConversationByUser(userID string, conversationID string) (Conv
 func (l Layer) GetConversationByID(conversationID string) (Conversation, error) {
 	var conversation Conversation
 	url := fmt.Sprintf("%s/apps/%s/conversations/%s", baseURL, l.ID, conversationID)
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return conversation, err
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
@@ -119,7 +138,7 @@ func (l Layer) GetConversationByID(conversationID string) (Conversation, error) 
 func (l Layer) CreateConversation(pending Conversation) (Conversation, error) {
 	var conversation Conversation
 	url := fmt.Sprintf("%s/apps/%s/conversations", baseURL, l.ID)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, false, pending)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, false, pending, l.Backoff)
 	if err != nil {
 		return conversation, err
 	}
@@ -140,7 +159,7 @@ func (l Layer) CreateConversation(pending Conversation) (Conversation, error) {
 func (l Layer) EditConversation(c Conversation, changes []EditRequest) (Conversation, error) {
 	var conversation Conversation
 	url := fmt.Sprintf("%s/apps/%s/conversations/%s", baseURL, l.ID, c.ID)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, true, false, changes)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, true, false, changes, l.Backoff)
 	if err != nil {
 		return conversation, err
 	} else if res.StatusCode != 200 && res.StatusCode != 201 {
@@ -159,7 +178,7 @@ func (l Layer) EditConversation(c Conversation, changes []EditRequest) (Conversa
 // globally to all members of the conversation and across devices
 func (l Layer) DeleteConversation(remove Conversation) error {
 	url := fmt.Sprintf("%s/apps/%s/conversations/%s", baseURL, l.ID, remove.ID)
-	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return err
 	} else if res.StatusCode != 204 {
@@ -180,7 +199,7 @@ func (l Layer) DeleteConversation(remove Conversation) error {
 func (l Layer) SendMessage(m Message, c Conversation) (Message, error) {
 	var message Message
 	url := fmt.Sprintf("%s/apps/%s/conversations/%s/messages", baseURL, l.ID, c.ID)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, false, m)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, false, m, l.Backoff)
 	if err != nil {
 		return message, err
 	} else if res.StatusCode != 201 {
@@ -213,7 +232,7 @@ func (l Layer) RetrieveMessages(c Conversation, pageSize int, fromID string) ([]
 	}
 
 	url := fmt.Sprintf("%s/apps/%s/conversations/%s/messages?%s", baseURL, l.ID, c.ID, params.Encode())
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return messages, err
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
@@ -236,7 +255,7 @@ func (l Layer) RetrieveMessages(c Conversation, pageSize int, fromID string) ([]
 func (l Layer) RetrieveMessagesByUser(userID string, c Conversation) ([]Message, error) {
 	var messages []Message
 	url := fmt.Sprintf("%s/apps/%s/users/%s/conversations/%s/messages", baseURL, l.ID, userID, c.ID)
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return messages, err
 	} else if res.StatusCode != 200 {
@@ -257,7 +276,7 @@ func (l Layer) RetrieveMessagesByUser(userID string, c Conversation) ([]Message,
 // DeleteMessage will delete the given message from the given conversation.
 func (l Layer) DeleteMessage(m Message, c Conversation) error {
 	url := fmt.Sprintf("%s/apps/%s/conversations/%s/messages/%s", baseURL, l.ID, c.ID, m.ID)
-	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return err
 	}
@@ -276,7 +295,7 @@ func (l Layer) DeleteMessage(m Message, c Conversation) error {
 // RegisterIdentity will create a new known user within Layer
 func (l Layer) RegisterIdentity(id string, i Identity) error {
 	url := fmt.Sprintf("%s/apps/%s/users/%s/identity", baseURL, l.ID, id)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, false, i)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, false, i, l.Backoff)
 	if err = res.Body.Close(); err != nil {
 		return err
 	}
@@ -288,7 +307,7 @@ func (l Layer) RegisterIdentity(id string, i Identity) error {
 func (l Layer) UpdateIdentity(id string, changes EditRequest) (Identity, error) {
 	var identity Identity
 	url := fmt.Sprintf("%s/apps/%s/users/%s/identity", baseURL, l.ID, id)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, true, false, changes)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, true, false, changes, l.Backoff)
 	if err != nil {
 		return identity, err
 	}
@@ -308,7 +327,7 @@ func (l Layer) UpdateIdentity(id string, changes EditRequest) (Identity, error) 
 func (l Layer) RetrieveIdentity(id string) (Identity, error) {
 	var identity Identity
 	url := fmt.Sprintf("%s/apps/%s/users/%s/identity", baseURL, l.ID, id)
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return identity, err
 	}
@@ -327,7 +346,7 @@ func (l Layer) RetrieveIdentity(id string) (Identity, error) {
 // DeleteIdentity will remove an Identity from Layer matching the given ID value
 func (l Layer) DeleteIdentity(id string) error {
 	url := fmt.Sprintf("%s/apps/%s/users/%s/identity", baseURL, l.ID, id)
-	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, false)
+	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, false, l.Backoff)
 	if err != nil {
 		return err
 	}
@@ -346,7 +365,7 @@ func (l Layer) DeleteIdentity(id string) error {
 func (l Layer) RegisterWebHook(created WebHook) (WebHook, error) {
 	var webhook WebHook
 	url := fmt.Sprintf("%s/apps/%s/webhooks", baseURL, l.ID)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, true, created)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, true, created, l.Backoff)
 	if err != nil {
 		return webhook, err
 	}
@@ -366,7 +385,7 @@ func (l Layer) RegisterWebHook(created WebHook) (WebHook, error) {
 func (l Layer) ListWebHooks() ([]WebHook, error) {
 	var webhooks []WebHook
 	url := fmt.Sprintf("%s/apps/%s/webhooks", baseURL, l.ID)
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, true)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, true, l.Backoff)
 	if err != nil {
 		return webhooks, err
 	}
@@ -387,7 +406,7 @@ func (l Layer) ListWebHooks() ([]WebHook, error) {
 func (l Layer) GetWebHook(id string) (WebHook, error) {
 	var webhook WebHook
 	url := fmt.Sprintf("%s/apps/%s/webhooks/%s", baseURL, l.ID, id)
-	res, err := makeLayerGetRequest(url, l.Token, l.Version, true)
+	res, err := makeLayerGetRequest(url, l.Token, l.Version, true, l.Backoff)
 	if err != nil {
 		return webhook, err
 	}
@@ -407,7 +426,7 @@ func (l Layer) GetWebHook(id string) (WebHook, error) {
 func (l Layer) ActivateWebHook(w WebHook) (WebHook, error) {
 	var webhook WebHook
 	url := fmt.Sprintf("%s/apps/%s/webhooks/%s/activate", baseURL, l.ID, w.ID)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, true, w)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, true, w, l.Backoff)
 	if err != nil {
 		return webhook, err
 	}
@@ -428,7 +447,7 @@ func (l Layer) ActivateWebHook(w WebHook) (WebHook, error) {
 func (l Layer) DeactivateWebHook(w WebHook) (WebHook, error) {
 	var webhook WebHook
 	url := fmt.Sprintf("%s/apps/%s/webhooks/%s/deactivate", baseURL, l.ID, w.ID)
-	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, true, w)
+	res, err := makeLayerPostRequest(url, l.Token, l.Version, false, true, w, l.Backoff)
 	if err != nil {
 		return webhook, err
 	}
@@ -447,7 +466,7 @@ func (l Layer) DeactivateWebHook(w WebHook) (WebHook, error) {
 // DeleteWebHook will remove the given WebHook instance from your Layer Account
 func (l Layer) DeleteWebHook(w WebHook) error {
 	url := fmt.Sprintf("%s/apps/%s/webhooks/%s", baseURL, l.ID, w.ID)
-	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, true)
+	res, err := makeLayerDeleteRequest(url, l.Token, l.Version, true, l.Backoff)
 	if err != nil {
 		return err
 	}
@@ -462,7 +481,7 @@ func (l Layer) DeleteWebHook(w WebHook) error {
 // --------------------------- PRIVATE FUNCTIONS -------------------------------
 // -----------------------------------------------------------------------------
 
-func makeLayerGetRequest(url string, token string, version string, isWebhook bool) (*http.Response, error) {
+func makeLayerGetRequest(url string, token string, version string, isWebhook bool, backoff Backoff) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return &http.Response{}, err
@@ -473,10 +492,10 @@ func makeLayerGetRequest(url string, token string, version string, isWebhook boo
 	} else {
 		req.Header.Add("Accept", fmt.Sprintf("application/vnd.layer+json; version=%s", version))
 	}
-	return client.Do(req)
+	return backoff.Do(req)
 }
 
-func makeLayerPostRequest(url string, token string, version string, isPatch bool, isWebhook bool, body interface{}) (*http.Response, error) {
+func makeLayerPostRequest(url string, token string, version string, isPatch bool, isWebhook bool, body interface{}, backoff Backoff) (*http.Response, error) {
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return &http.Response{}, err
@@ -498,10 +517,10 @@ func makeLayerPostRequest(url string, token string, version string, isPatch bool
 		req.Header.Add("Content-Type", "application/json")
 	}
 
-	return client.Do(req)
+	return backoff.Do(req)
 }
 
-func makeLayerDeleteRequest(url string, token string, version string, isWebhook bool) (*http.Response, error) {
+func makeLayerDeleteRequest(url string, token string, version string, isWebhook bool, backoff Backoff) (*http.Response, error) {
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return &http.Response{}, err
@@ -513,5 +532,42 @@ func makeLayerDeleteRequest(url string, token string, version string, isWebhook 
 		req.Header.Add("Accept", fmt.Sprintf("application/vnd.layer+json; version=%s", version))
 	}
 
-	return client.Do(req)
+	return backoff.Do(req)
+}
+
+// Do executes an HTTP request using the given backoff configuration.
+func (b Backoff) Do(req *http.Request) (*http.Response, error) {
+	var counter int
+	loop := true
+
+	for loop {
+		// Doing this to simulate a do...while() loop. Need to always execute once.
+		if counter >= b.NumTries {
+			loop = false
+		}
+
+		// If this isn't the first iteration, start backing off.
+		if counter > 0 {
+			exponential := int(float64(b.MinTime) * math.Pow(2.0, float64(counter)))
+			waitTime := b.MaxTime
+
+			if exponential < b.MaxTime {
+				waitTime = exponential
+			}
+
+			time.Sleep(time.Duration(waitTime) * time.Millisecond)
+		}
+
+		res, err := client.Do(req)
+		if err == nil {
+			// Need to evaluate if this range of status codes is correct.
+			if res.StatusCode > 199 && res.StatusCode < 399 {
+				return res, nil
+			}
+		}
+
+		counter++
+	}
+
+	return nil, fmt.Errorf("Request failed after attempting backoff")
 }


### PR DESCRIPTION
I went back and forth on where this logic should live and ended up putting it here for two reasons.

1. Layer actually performs some kind of backoff in their own SDKs, so it seemed like it wouldn't be too crazy to include it in glare.
2. It was massively easier to add backoff here then everywhere glare is used.

It works by attempting to retry a request up to Backoff.NumTries times. It will start by waiting Backoff.MinTime milliseconds and grow exponentially from there, up to Backoff.MaxTime. So given a configuration of...
```go
backoff := Backoff {
    NumTries: 10,
    MinTime: 200,
    MaxTime: 5000,
}
```
A request will be attempted, at most, 10 times. The pattern on a repeatedly failing request would look like:
```
200ms
800ms
1800ms
3200ms
5000ms
5000ms
5000ms
5000ms
5000ms
5000ms
Request failed
```

There are some things that could probably be done differently, but this seemed like the least intrusive way of adding backoff in (there's really only additions, not really any removals or rewrites). If it makes more sense to spend time integrating backoff as more of a core thing, we can definitely talk through that.