### PR TITLE
Fixing Typo

### DIFF
--- a/message.go
+++ b/message.go
@@ -21,7 +21,7 @@ type Message struct {
 		Name   string `json:"name,omitempty"`
 		UserID string `json:"user_id,omitempty"`
 	} `json:"sender"`
-	SentAt           *time.Time `json:"send_at,omitempty"`
+	SentAt           *time.Time `json:"sent_at,omitempty"`
 	FromConversation struct {
 		ID  string `json:"id"`
 		URL string `json:"url"`


### PR DESCRIPTION
The field name returned by Layer is actually "sent_at". Not sure exactly how we're getting that field all the way through to the consumer (it appears as sent_at...but it's a zero-value date), but this seems to fix it.