### PR TITLE
Adding nil check to response pointer in backoff.Do()

### DIFF
--- a/glare.go
+++ b/glare.go
@@ -615,9 +615,15 @@ func (b Backoff) Do(req *http.Request) (*http.Response, error) {
 		res, err := client.Do(req)
 		latency := (time.Now().UnixNano() / 1000000) - startTime
 
+		// Have to make sure we have a response object before peeling the status code.
+		var statusCode int
+		if res != nil {
+			statusCode = res.StatusCode
+		}
+
 		layerLog := LayerLog{
 			URL:        req.URL.String(),
-			StatusCode: res.StatusCode,
+			StatusCode: statusCode,
 			Method:     req.Method,
 			Latency:    latency,
 		}


### PR DESCRIPTION
In the unusual case where we get a nil response when calling backoff.Do, asking for res.StatusCode causes a panic.

Sidenote:
This logging/backoff stuff is starting to get ugly. Probably need to look at refactoring this soonish.