### PR TITLE
Patching conversation destruction

### DIFF
--- a/glare.go
+++ b/glare.go
@@ -186,7 +186,7 @@ func (l Layer) DeleteConversation(remove Conversation) error {
 		return err
 	}
 
-	if res.StatusCode != 204 {
+	if res.StatusCode < 200 || res.StatusCode > 299 {
 		msg, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return err

--- a/glare.go
+++ b/glare.go
@@ -187,12 +187,14 @@ func (l Layer) DeleteConversation(remove Conversation) error {
 	}
 
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		msg, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
+		if res.StatusCode != 404 {
+			msg, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
 
-		return fmt.Errorf("%d: %s", res.StatusCode, string(msg))
+			return fmt.Errorf("%d: %s", res.StatusCode, string(msg))
+		}
 	}
 
 	return res.Body.Close()
@@ -641,6 +643,11 @@ func (b Backoff) Do(req *http.Request) (*http.Response, error) {
 		}
 
 		if err == nil {
+			// For deletes, a 404 response shouldn't be an error.
+			if req.Method == "DELETE" && res.StatusCode == 404 {
+				return res, nil
+			}
+
 			// Need to evaluate if this range of status codes is correct.
 			if res.StatusCode > 199 && res.StatusCode < 399 {
 				return res, nil


### PR DESCRIPTION
The error handling for Delete requests, especially with exponential backoff, needed some tweaking. This treats 404s as a non-error since it really only means you tried to delete something that doesn't exist. This means that we don't retry 404 requests a bunch of times.