### PR TITLE
Omitting empty ID fields

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -6,7 +6,7 @@ import (
 
 // Conversation represents a single conversation resource from the Layer API
 type Conversation struct {
-	ID                 string                 `json:"id"`
+	ID                 string                 `json:"id,omitempty"`
 	URL                string                 `json:"url"`
 	MessagesURL        string                 `json:"messages_url"`
 	CreatedAt          *time.Time             `json:"created_at,omitempty"`

--- a/message.go
+++ b/message.go
@@ -6,11 +6,11 @@ import (
 
 // Message represents a single message resource from the Layer API
 type Message struct {
-	ID       string `json:"id"`
+	ID       string `json:"id,omitempty"`
 	URL      string `json:"url"`
 	IsUnread bool   `json:"is_unread"`
 	Parts    []struct {
-		ID       string                 `json:"id"`
+		ID       string                 `json:"id,omitempty"`
 		MimeType string                 `json:"mime_type"`
 		Content  map[string]interface{} `json:"content"`
 		Body     string                 `json:"body"`


### PR DESCRIPTION
Layer updated their endpoints to validate some fields. Apparently blank ID fields are no longer allowed.